### PR TITLE
Fixing error output

### DIFF
--- a/extip/data_source.go
+++ b/extip/data_source.go
@@ -65,7 +65,7 @@ func dataSourceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("ipaddress", string(ip))
 		d.SetId(time.Now().UTC().String())
 	} else {
-		return fmt.Errorf("Error requesting external IP: %d", err)
+		return fmt.Errorf("Error requesting external IP: %s", err.Error())
 	}
 
 	return nil

--- a/extip/data_source_test.go
+++ b/extip/data_source_test.go
@@ -150,3 +150,24 @@ func TestDataSource_DefaultResolver(t *testing.T) {
 		},
 	})
 }
+
+const testDataSourceNonExistant = `
+data "extip" "not_real" {
+	resolver = "https://notrealsite.fakeurl"
+}
+output "ipaddress" {
+  value = data.extip.not_real.ipaddress
+}
+`
+
+func TestDataSource_NonExistant(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      testDataSourceNonExistant,
+				ExpectError: regexp.MustCompile("Error requesting external IP: Get \"https://notrealsite.fakeurl\": dial tcp: lookup notrealsite.fakeurl.+no such host"),
+			},
+		},
+	})
+}


### PR DESCRIPTION
* Previously we weren’t parsing the error so we’d get error messages like:
```
Error requesting external IP: &{%!d(string=Get) %!d(string=https://notrealsite.fakeurl) 824638600912}
```
* Now it looks better: 
```
Error requesting external IP: Get \"https://notrealsite.fakeurl\": dial tcp: lookup notrealsite.fakeurl: no such host
```